### PR TITLE
update clunk submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "clunk"]
 	path = clunk
-	url = git://github.com/whoozle/clunk.git
+	url = https://github.com/whoozle/clunk.git


### PR DESCRIPTION
The old link format is no longer supported on GitHub.